### PR TITLE
🐛 Fix VichUploader cache permissions causing 500 error on login_check API

### DIFF
--- a/app/config/packages/vich_uploader.yaml
+++ b/app/config/packages/vich_uploader.yaml
@@ -1,5 +1,9 @@
 vich_uploader:
     db_driver: orm
+    metadata:
+        type: attribute
+        cache: file
+        cache_dir: '%kernel.cache_dir%/vich_uploader'
     mappings:
         session_documents:
             uri_prefix: /uploads/sessions

--- a/docker/php/dockerfile
+++ b/docker/php/dockerfile
@@ -38,5 +38,12 @@ RUN usermod -u ${USER_ID} www-data && groupmod -g ${GROUP_ID} www-data
 
 WORKDIR /var/www/
 
+# Create cache directories and set proper permissions
+RUN mkdir -p /var/www/var/cache/prod/vich_uploader \
+    && mkdir -p /var/www/var/cache/dev/vich_uploader \
+    && mkdir -p /var/www/var/log \
+    && chown -R www-data:www-data /var/www/var \
+    && chmod -R 755 /var/www/var
+
 # On garde le conteneur actif
 CMD ["php-fpm"]


### PR DESCRIPTION
## Problème résolu
Correction de l'erreur 500 sur l'endpoint `/api/login_check` causée par un problème de permissions du répertoire de cache VichUploader.

## Erreur originale
```
"The directory '/var/www/var/cache/prod/vich_uploader' is not writable."
```

## Solutions appliquées

### 1. Correction du Dockerfile (`docker/php/dockerfile`)
- Ajout de la création des répertoires de cache VichUploader pour les environnements `prod` et `dev`
- Configuration des permissions appropriées avec `chown` et `chmod`
- Attribution des bonnes propriétés au user `www-data`

### 2. Optimisation de la configuration VichUploader (`app/config/packages/vich_uploader.yaml`)
- Configuration explicite du cache de métadonnées
- Utilisation du système de cache de Symfony avec `%kernel.cache_dir%`
- Amélioration des performances et prévention des problèmes de permissions

## Test de la solution
Une fois ces changements déployés :

1. Reconstruire l'image Docker : `docker-compose build php`
2. Relancer les conteneurs : `docker-compose up -d`
3. Tester l'endpoint de connexion :
```bash
curl -X POST http://193.108.53.178/api/login_check \
  -H "Content-Type: application/json" \
  -d '{"email": "admin@merelformation.fr", "password": "admin123"}'
```

## Impact
- ✅ Résolution de l'erreur 500 sur l'authentification
- ✅ Amélioration des performances de VichUploader
- ✅ Prévention des futurs problèmes de permissions de cache
- ✅ Compatibilité avec tous les environnements (dev, test, prod)