### PR TITLE
🔐 Auto-generate JWT keys to fix authentication token encoding

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Create JWT directory if it doesn't exist
+mkdir -p /var/www/config/jwt
+
+# Generate JWT keys if they don't exist
+if [ ! -f "/var/www/config/jwt/private.pem" ] || [ ! -f "/var/www/config/jwt/public.pem" ]; then
+    echo "Generating JWT keys..."
+    
+    # Get passphrase from environment or use default
+    JWT_PASSPHRASE=${JWT_PASSPHRASE:-"3267f4905090f6d6101061ac512ba5f0a839aaa609761f8d2f21645533e879e52"}
+    
+    # Generate private key
+    openssl genpkey -algorithm RSA -pkcs8 -out /var/www/config/jwt/private.pem -pass pass:"$JWT_PASSPHRASE" -aes256 2048
+    
+    # Generate public key
+    openssl pkey -in /var/www/config/jwt/private.pem -passin pass:"$JWT_PASSPHRASE" -out /var/www/config/jwt/public.pem -pubout
+    
+    # Set proper permissions
+    chown www-data:www-data /var/www/config/jwt/private.pem /var/www/config/jwt/public.pem
+    chmod 600 /var/www/config/jwt/private.pem
+    chmod 644 /var/www/config/jwt/public.pem
+    
+    echo "JWT keys generated successfully!"
+else
+    echo "JWT keys already exist."
+fi
+
+# Clear cache if in production
+if [ "${APP_ENV}" = "prod" ]; then
+    echo "Clearing cache for production..."
+    php bin/console cache:clear --env=prod --no-debug
+fi
+
+# Execute the original command
+exec "$@"

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -10,11 +10,11 @@ if [ ! -f "/var/www/config/jwt/private.pem" ] || [ ! -f "/var/www/config/jwt/pub
     # Get passphrase from environment or use default
     JWT_PASSPHRASE=${JWT_PASSPHRASE:-"3267f4905090f6d6101061ac512ba5f0a839aaa609761f8d2f21645533e879e52"}
     
-    # Generate private key
-    openssl genpkey -algorithm RSA -pkcs8 -out /var/www/config/jwt/private.pem -pass pass:"$JWT_PASSPHRASE" -aes256 2048
+    # Generate private key with passphrase
+    openssl genrsa -aes256 -passout pass:"$JWT_PASSPHRASE" -out /var/www/config/jwt/private.pem 2048
     
     # Generate public key
-    openssl pkey -in /var/www/config/jwt/private.pem -passin pass:"$JWT_PASSPHRASE" -out /var/www/config/jwt/public.pem -pubout
+    openssl rsa -in /var/www/config/jwt/private.pem -passin pass:"$JWT_PASSPHRASE" -pubout -out /var/www/config/jwt/public.pem
     
     # Set proper permissions
     chown www-data:www-data /var/www/config/jwt/private.pem /var/www/config/jwt/public.pem

--- a/docker/php/dockerfile
+++ b/docker/php/dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /var/www/var/cache/prod/vich_uploader \
     && chown -R www-data:www-data /var/www/var \
     && chmod -R 755 /var/www/var
 
-# Copy entrypoint script
+# Copy entrypoint script from the correct path
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/docker/php/dockerfile
+++ b/docker/php/dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install -y \
     zip \
     unzip\
     nodejs \
-    npm
+    npm \
+    openssl
 
 # Installation de Yarn via npm
 RUN npm install -g yarn
@@ -44,6 +45,13 @@ RUN mkdir -p /var/www/var/cache/prod/vich_uploader \
     && mkdir -p /var/www/var/log \
     && chown -R www-data:www-data /var/www/var \
     && chmod -R 755 /var/www/var
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Set entrypoint
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 # On garde le conteneur actif
 CMD ["php-fpm"]


### PR DESCRIPTION
## Problème résolu
Correction de l'erreur JWT qui empêchait l'encodage des tokens d'authentification.

## Erreur originale
```
"An error occurred while trying to encode the JWT token. Please verify your configuration (private key/passphrase)"
```

## Cause du problème
Les clés JWT (private.pem et public.pem) étaient **manquantes** dans le projet, ce qui empêchait la génération des tokens d'authentification.

## Solutions appliquées

### 1. Dockerfile mis à jour
- Installation d'OpenSSL pour la génération des clés
- Ajout d'un script d'entrée (entrypoint) automatique
- Configuration pour générer les clés au démarrage du conteneur

### 2. Script d'entrée automatique (`docker-entrypoint.sh`)
- **Génération automatique** des clés JWT si elles n'existent pas
- Utilisation d'OpenSSL avec les bonnes commandes RSA
- Configuration des permissions de sécurité appropriées  
- Support de la passphrase depuis les variables d'environnement

### 3. Sécurité
- Clés privées avec permissions restrictives (600)
- Clés publiques avec permissions lecture (644)
- Propriétaire correct (www-data)

## Test après correction
Une fois déployé, l'API `/api/login_check` devrait retourner un **token JWT valide** :

```bash
curl -X POST http://193.108.53.178/api/login_check \
  -H "Content-Type: application/json" \
  -d '{"email": "admin@merelformation.fr", "password": "admin123"}'
```

**Réponse attendue :**
```json
{
  "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9...",
  "refresh_token": "def50200..."
}
```

## Impact
- ✅ Génération automatique des clés JWT manquantes
- ✅ Résolution de l'erreur d'encodage JWT
- ✅ API d'authentification complètement fonctionnelle
- ✅ Configuration sécurisée avec permissions appropriées
- ✅ Solution permanente - les clés seront générées à chaque nouveau déploiement