### PR TITLE
🔧 Fix database credentials consistency in production docker-compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,7 +29,7 @@ services:
       - ./app:/var/www
     environment:
       - APP_ENV=prod
-      - DATABASE_URL=mysql://merel_user:merel_password@mysql:3306/merel_db
+      - DATABASE_URL=mysql://merel_user:merel_pass@mysql:3306/merel_db
     depends_on:
       - mysql
     networks:
@@ -45,7 +45,7 @@ services:
       MYSQL_ROOT_PASSWORD: secureRootPass123
       MYSQL_DATABASE: merel_db
       MYSQL_USER: merel_user
-      MYSQL_PASSWORD: merel_password
+      MYSQL_PASSWORD: merel_pass
     networks:
       - merel_network
     restart: always


### PR DESCRIPTION
## Problème résolu
Correction de l'incohérence des credentials de base de données dans le fichier de production `docker-compose.prod.yml`.

## Problème détecté
Dans le `docker-compose.prod.yml`, le mot de passe MySQL était encore configuré avec l'ancienne valeur :
- **DATABASE_URL** : `merel_password` ❌
- **MYSQL_PASSWORD** : `merel_password` ❌

Alors que dans le `.env.prod` et `docker-compose.yml`, nous utilisons maintenant :
- **Mot de passe correct** : `merel_pass` ✅

## Solution appliquée
Correction des deux occurrences dans `docker-compose.prod.yml` :
1. Variable d'environnement `DATABASE_URL` du service PHP
2. Variable d'environnement `MYSQL_PASSWORD` du service MySQL

## Impact
Cette correction assure la **cohérence complète** entre :
- ✅ `.env.prod`
- ✅ `docker-compose.yml` (développement)  
- ✅ `docker-compose.prod.yml` (production)

## Test
Le script `deploy.sh` devrait maintenant fonctionner correctement sans erreurs de connexion à la base de données.