### PR TITLE
🛠️ Fix: Add MySQL data persistence to prevent data loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,124 @@
+# MerelFormation
+
+Plateforme de gestion de formations taxi avec système de location de véhicules.
+
+## 🚀 Installation et Configuration
+
+### Prérequis
+- Docker et Docker Compose
+- Git
+
+### Installation
+```bash
+# Cloner le projet
+git clone https://github.com/ouerghi-selim/MerelFormation.git
+cd MerelFormation
+
+# Configurer les répertoires de données
+chmod +x setup-data-directories.sh
+./setup-data-directories.sh
+
+# Lancer l'environnement de développement
+docker-compose up -d
+```
+
+## 📊 Gestion des Données MySQL
+
+### ✅ Persistance des Données
+Les données MySQL sont **automatiquement persistées** grâce au volume configuré :
+```yaml
+volumes:
+  - ./data/mysql:/var/lib/mysql
+```
+
+### 🔄 Commandes Docker importantes
+
+#### Arrêter sans perdre les données
+```bash
+docker-compose down
+# ✅ Les données MySQL sont conservées
+```
+
+#### Redémarrer l'application
+```bash
+docker-compose up -d
+# ✅ Vos données seront toujours là
+```
+
+#### ⚠️ ATTENTION : Supprimer TOUTES les données
+```bash
+docker-compose down -v
+# ❌ Cette commande supprime TOUS les volumes (données perdues)
+```
+
+### 🧪 Comment tester la persistance
+
+1. **Démarrer l'application :**
+   ```bash
+   docker-compose up -d
+   ```
+
+2. **Accéder à phpMyAdmin :** http://localhost:8081
+   - Serveur : `mysql`
+   - Utilisateur : `merel_user`
+   - Mot de passe : `merel_pass`
+
+3. **Créer des données de test** dans la base `merel_db`
+
+4. **Arrêter l'application :**
+   ```bash
+   docker-compose down
+   ```
+
+5. **Redémarrer :**
+   ```bash
+   docker-compose up -d
+   ```
+
+6. **Vérifier** que vos données sont toujours présentes dans phpMyAdmin
+
+## 🌐 Accès aux Services
+
+- **Application principale :** http://localhost
+- **phpMyAdmin :** http://localhost:8081
+- **MailHog :** http://localhost:8025
+- **Frontend (dev) :** http://localhost:5173
+
+## 📁 Structure des Données
+
+```
+data/
+└── mysql/          # Données MySQL persistées
+    ├── ibdata1
+    ├── mysql/
+    └── merel_db/    # Votre base de données
+```
+
+## 🛠️ Dépannage
+
+### Les données disparaissent ?
+- Vérifiez que le répertoire `./data/mysql` existe
+- Assurez-vous d'utiliser `docker-compose down` (sans `-v`)
+- Vérifiez les permissions du répertoire `data/`
+
+### Réinitialiser complètement la base
+```bash
+# Attention : supprime TOUTES les données
+docker-compose down -v
+rm -rf data/mysql
+./setup-data-directories.sh
+docker-compose up -d
+```
+
+## 🚀 Déploiement Production
+
+Pour la production, utilisez :
+```bash
+docker-compose -f docker-compose.prod.yml up -d
+```
+
+## 📝 Notes importantes
+
+- **Sauvegardez régulièrement** le répertoire `data/mysql`
+- N'utilisez **jamais** `docker-compose down -v` en production
+- Les données sont stockées localement dans `./data/mysql`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,9 @@ services:
     container_name: merel_mysql
     ports:
       - "3306:3306"
+    volumes:
+      # ✅ AJOUT : Volume pour persister les données MySQL
+      - ./data/mysql:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: merel_db

--- a/setup-data-directories.sh
+++ b/setup-data-directories.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Script pour vérifier et créer les répertoires de données nécessaires
+# Utilisation: ./setup-data-directories.sh
+
+echo "🗂️ Configuration des répertoires de données pour MerelFormation..."
+
+# Créer les répertoires de données s'ils n'existent pas
+mkdir -p data/mysql
+echo "✅ Répertoire data/mysql créé/vérifié"
+
+# Vérifier les permissions
+echo "🔍 Vérification des permissions..."
+
+# Afficher les informations sur le répertoire
+if [ -d "data/mysql" ]; then
+    echo "📁 Répertoire data/mysql existe et est prêt"
+    ls -la data/
+else
+    echo "❌ Erreur : Répertoire data/mysql non créé"
+    exit 1
+fi
+
+echo ""
+echo "🎉 Configuration terminée avec succès !"
+echo ""
+echo "📋 Instructions pour tester la persistance des données :"
+echo "   1. Démarrer : docker-compose up -d"
+echo "   2. Créer des données de test dans la base"
+echo "   3. Arrêter : docker-compose down"
+echo "   4. Redémarrer : docker-compose up -d"
+echo "   5. Vérifier que les données sont toujours présentes"
+echo ""
+echo "⚠️ Note importante :"
+echo "   - docker-compose down : Garde les données (volume conservé)"
+echo "   - docker-compose down -v : Supprime TOUT (volumes supprimés)"
+echo ""


### PR DESCRIPTION
## 🛠️ Problème résolu
Correction du problème de **perte de données MySQL** lors des redémarrages de containers Docker.

## 🔄 Changements apportés

### 1. **docker-compose.yml** corrigé
- ✅ Ajout du volume `./data/mysql:/var/lib/mysql` pour MySQL
- ✅ Alignement avec la configuration de production
- ✅ Prévention de la perte de données lors de `docker-compose down`

### 2. **Script de configuration** ajouté
- ✅ `setup-data-directories.sh` pour créer les répertoires nécessaires
- ✅ Instructions claires pour tester la persistance
- ✅ Distinction entre commandes sûres et dangereuses

### 3. **Documentation complète**
- ✅ README.md détaillé avec guide de gestion des données
- ✅ Procédures de test de persistance
- ✅ Section dépannage pour les problèmes courants

## 🧪 Comment tester
```bash
# 1. Créer les répertoires
./setup-data-directories.sh

# 2. Démarrer
docker-compose up -d

# 3. Ajouter des données via phpMyAdmin (localhost:8081)

# 4. Arrêter
docker-compose down

# 5. Redémarrer
docker-compose up -d

# 6. Vérifier que les données sont toujours là
```

## ⚠️ Important
- **`docker-compose down`** : ✅ Sûr (garde les données)
- **`docker-compose down -v`** : ❌ Dangereux (supprime tout)

## 📊 Impact
- ✅ Aucune perte de données lors des redémarrages
- ✅ Cohérence entre développement et production
- ✅ Documentation claire pour l'équipe