### PR TITLE
🔧 Add MailHog to Production for Email Testing

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,8 +30,10 @@ services:
     environment:
       - APP_ENV=prod
       - DATABASE_URL=mysql://merel_user:merel_password@mysql:3306/merel_db
+      - MAILER_DSN=smtp://mailhog:1025
     depends_on:
       - mysql
+      - mailhog
     networks:
       - merel_network
     restart: always
@@ -46,6 +48,17 @@ services:
       MYSQL_DATABASE: merel_db
       MYSQL_USER: merel_user
       MYSQL_PASSWORD: merel_password
+    networks:
+      - merel_network
+    restart: always
+
+  # ✅ AJOUT : MailHog pour tester les emails en production
+  mailhog:
+    image: mailhog/mailhog
+    container_name: merel_mailhog_prod
+    ports:
+      - "1025:1025"   # Port SMTP
+      - "8025:8025"   # Interface web MailHog
     networks:
       - merel_network
     restart: always

--- a/docs/MAILHOG_PRODUCTION.md
+++ b/docs/MAILHOG_PRODUCTION.md
@@ -1,0 +1,66 @@
+# Configuration MailHog pour Production
+
+## 🎯 Objectif
+Permettre le test des emails en production sans domaine ni gestionnaire de mail configuré.
+
+## 📧 Configuration MailHog Production
+
+### Services Ajoutés
+```yaml
+mailhog:
+  image: mailhog/mailhog
+  container_name: merel_mailhog_prod
+  ports:
+    - "1025:1025"   # Port SMTP
+    - "8025:8025"   # Interface web MailHog
+  networks:
+    - merel_network
+  restart: always
+```
+
+### Configuration PHP
+La variable d'environnement suivante a été ajoutée au service PHP :
+```yaml
+- MAILER_DSN=smtp://mailhog:1025
+```
+
+## 🚀 Déploiement
+
+### 1. Mettre à jour la production
+```bash
+git pull origin feature/mailhog-production
+docker-compose -f docker-compose.prod.yml down
+docker-compose -f docker-compose.prod.yml up -d
+```
+
+### 2. Accéder à MailHog
+- **Interface Web :** http://VOTRE-IP-SERVEUR:8025
+- **Port SMTP :** 1025 (utilisé automatiquement par Symfony)
+
+## 🧪 Test des Emails
+
+### Envoyer un email de test depuis Symfony
+Vous pouvez maintenant utiliser le service de mail Symfony normalement. Tous les emails seront interceptés par MailHog.
+
+### Vérifier la réception
+1. Ouvrez http://VOTRE-IP-SERVEUR:8025 dans votre navigateur
+2. Tous les emails envoyés par l'application apparaîtront dans l'interface MailHog
+3. Vous pouvez voir le contenu HTML/texte, les headers, etc.
+
+## 🔧 Utilisation Temporaire
+Cette configuration est idéale pour :
+- ✅ Tests de fonctionnalités email en production
+- ✅ Validation des templates email
+- ✅ Debug des envois automatiques
+- ✅ Tests avant mise en place du vrai serveur mail
+
+## 🚨 Important
+- Cette configuration est pour les TESTS uniquement
+- Ne pas utiliser en production finale avec de vrais utilisateurs
+- Remplacer par un vrai serveur SMTP quand prêt
+
+## 🔄 Retour en arrière
+Pour désactiver MailHog :
+1. Supprimer le service `mailhog` du docker-compose.prod.yml
+2. Modifier `MAILER_DSN` dans la section `php.environment`
+3. Redémarrer : `docker-compose -f docker-compose.prod.yml up -d`


### PR DESCRIPTION
## 🎯 Objectif
Ajouter MailHog en production pour permettre les tests d'emails sans nom de domaine ni gestionnaire de mail configuré.

## 📋 Modifications Apportées

### ✅ docker-compose.prod.yml
- **Ajout du service MailHog** avec ports 1025 (SMTP) et 8025 (interface web)
- **Configuration MAILER_DSN** pour utiliser MailHog automatiquement
- **Dépendance ajoutée** entre PHP et MailHog

### ✅ Documentation
- **Nouveau fichier** `docs/MAILHOG_PRODUCTION.md`
- **Instructions de déploiement** complètes
- **Guide d'utilisation** pour les tests email
- **Procédure de retour en arrière** si nécessaire

## 🚀 Comment Tester

### 1. Déployer les modifications
```bash
git pull origin feature/mailhog-production
docker-compose -f docker-compose.prod.yml down
docker-compose -f docker-compose.prod.yml up -d
```

### 2. Accéder à MailHog
- **Interface Web :** `http://VOTRE-IP:8025`
- Tous les emails envoyés par l'application y apparaîtront

### 3. Tester l'envoi d'emails
- Les emails de l'application (confirmations, notifications, etc.) seront interceptés
- Interface intuitive pour voir contenu HTML/texte, headers, etc.

## 🔧 Avantages

✅ **Test complet** des fonctionnalités email en production  
✅ **Aucune configuration email externe** requise  
✅ **Interface visuelle** pour débugger les emails  
✅ **Facilement réversible** si besoin  
✅ **Même expérience** qu'en développement local  

## ⚠️ Important
Cette configuration est temporaire pour les **tests uniquement**. À remplacer par un vrai serveur SMTP en production finale.

## 🧪 Tests à Effectuer
- [ ] Confirmation d'inscription formation
- [ ] Notification de réservation véhicule  
- [ ] Emails administratifs
- [ ] Templates personnalisés

Ready for production email testing! 🚀📧