### PR TITLE
🔧 Fix: Add .gitignore to resolve production Git conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,134 @@
+# ===========================================
+# MerelFormation - .gitignore
+# ===========================================
+
+# ===== PRODUCTION DATA =====
+# Données MySQL et volumes Docker
+data/
+*.sql
+*.db
+
+# Certificats SSL et Let's Encrypt
+data/certbot/
+data/letsencrypt/
+
+# ===== SYMFONY BACKEND =====
+# Environment files
+app/.env
+app/.env.local
+app/.env.local.php
+app/.env.*.local
+
+# Cache and logs
+app/var/cache/
+app/var/log/
+app/var/sessions/
+
+# Uploads
+app/public/uploads/
+app/public/media/
+
+# Composer
+app/vendor/
+
+# JWT Keys (should be generated)
+app/config/jwt/*.pem
+
+# Doctrine
+app/migrations/*.php.bak
+
+# PHPUnit
+app/.phpunit
+app/.phpunit.result.cache
+
+# ===== REACT FRONTEND =====
+# Dependencies
+frontend/node_modules/
+frontend/.pnp
+frontend/.pnp.js
+
+# Production build
+frontend/dist/
+frontend/build/
+
+# Build artifacts copied to Symfony public
+app/public/build/
+app/public/assets/
+
+# Runtime data
+frontend/.env.local
+frontend/.env.development.local
+frontend/.env.test.local
+frontend/.env.production.local
+
+# Logs
+frontend/npm-debug.log*
+frontend/yarn-debug.log*
+frontend/yarn-error.log*
+
+# ESLint cache
+frontend/.eslintcache
+
+# Vite cache
+frontend/.vite/
+
+# ===== DOCKER =====
+# Docker volumes
+docker/volumes/
+
+# ===== SYSTEM FILES =====
+# MacOS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Windows
+*.tmp
+*.swp
+*.swo
+*~
+
+# Linux
+*~
+
+# ===== IDE FILES =====
+# VSCode
+.vscode/
+
+# PhpStorm
+.idea/
+
+# Sublime Text
+*.sublime-project
+*.sublime-workspace
+
+# ===== TEMPORARY FILES =====
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+*.temp
+
+# ===== CUSTOM SCRIPTS =====
+# Local deployment scripts (keep deploy.sh but ignore local variants)
+deploy.local.sh
+*.local.sh
+
+# Backup files
+*.bak
+*.backup
+
+# ===== SECURITY =====
+# Private keys
+*.pem
+*.key
+*.crt
+
+# Secrets
+secrets/
+.secrets


### PR DESCRIPTION
## 🎯 Problème Résolu
Ajout d'un fichier `.gitignore` complet pour éviter que Git trackent les fichiers de production et de build.

## 🐛 Problème Identifié
- Aucun `.gitignore` à la racine du projet
- Git essaie de tracker les données MySQL (`data/`)
- Git trackent les fichiers de build frontend (`app/public/build/`)
- Impossible de faire `git pull` en production

## ✅ Solution Implémentée

### Fichiers/Dossiers Exclus
- **`data/`** - Données MySQL et volumes Docker
- **`app/public/build/`** - Fichiers générés par le build frontend
- **`app/var/cache/`** - Cache Symfony
- **`app/var/log/`** - Logs Symfony
- **`app/public/uploads/`** - Uploads utilisateur
- **`frontend/node_modules/`** - Dépendances Node.js
- **`frontend/dist/`** - Build de production React
- **`.env` files** - Variables d'environnement
- **Fichiers système** (.DS_Store, Thumbs.db, etc.)
- **Fichiers IDE** (.vscode/, .idea/)

## 🚀 Instructions pour Résoudre le Problème sur le Serveur

Après merge de cette PR, exécuter sur le serveur de production :

```bash
# 1. Nettoyer l'état Git
git reset --hard HEAD
git clean -fd

# 2. Récupérer les modifications avec le .gitignore
git pull origin main

# 3. Redémarrer les services Docker
docker-compose -f docker-compose.prod.yml down
docker-compose -f docker-compose.prod.yml up -d
```

## 🔧 Avantages
✅ Plus de conflits Git avec les fichiers de production  
✅ Repository plus propre  
✅ Déploiements simplifiés  
✅ Sécurité renforcée (pas de secrets accidentellement commitués)  

Production Git issues resolved! 🎉